### PR TITLE
Added Artifact Saving for W&B

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ train_mobilenet:
 	--width 224 \
 	--optim amsgrad \
 	--lr 0.0003 \
-	--max-epoch 1 \
+	--max-epoch 10 \
 	--stepsize 20 40 \
 	--train-batch-size 64 \
 	--test-batch-size 100 \

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,6 @@ train_mobilenet:
 	--test-batch-size 100 \
 	--save-dir logs/mobilenet_v3_small-veri
 
-
 .PHONY: train_resnet18
 train_resnet18:
 	python main.py \
@@ -33,6 +32,56 @@ train_resnet18:
 	--test-batch-size 100 \
 	--save-dir logs/resnet18-veri
 
+.PHONY: train_resnet34
+train_resnet18:
+	python main.py \
+	-s veri \
+	-t veri \
+	-a resnet34 \
+	--root src/datasets/ \
+	--height 224 \
+	--width 224 \
+	--optim amsgrad \
+	--lr 0.0003 \
+	--max-epoch 10 \
+	--stepsize 20 40 \
+	--train-batch-size 64 \
+	--test-batch-size 100 \
+	--save-dir logs/resnet34-veri
+
+.PHONY: train_resnet50
+train_resnet50:
+	python main.py \
+	-s veri \
+	-t veri \
+	-a resnet50 \
+	--root src/datasets/ \
+	--height 224 \
+	--width 224 \
+	--optim amsgrad \
+	--lr 0.0003 \
+	--max-epoch 10 \
+	--stepsize 20 40 \
+	--train-batch-size 64 \
+	--test-batch-size 100 \
+	--save-dir logs/resnet50-veri
+
+.PHONY: train_vgg16
+train_vgg16:
+	python main.py \
+	-s veri \
+	-t veri \
+	-a vgg16 \
+	--root src/datasets/ \
+	--height 224 \
+	--width 224 \
+	--optim amsgrad \
+	--lr 0.0003 \
+	--max-epoch 10 \
+	--stepsize 20 40 \
+	--train-batch-size 64 \
+	--test-batch-size 100 \
+	--save-dir logs/vgg16-veri
 
 .PHONY: eval
 eval:

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ train_mobilenet:
 	--width 224 \
 	--optim amsgrad \
 	--lr 0.0003 \
-	--max-epoch 10 \
+	--max-epoch 1 \
 	--stepsize 20 40 \
 	--train-batch-size 64 \
 	--test-batch-size 100 \

--- a/main.py
+++ b/main.py
@@ -179,7 +179,9 @@ def main():
             )
 
             checkpoint_path = osp.join(args.save_dir, f"model.pth.tar-{epoch + 1}")
+            weights_checkpoint_path = osp.join(args.save_dir, f"model_weights.pth.tar-{epoch + 1}")
             wandb_logger.log_model_artifact(checkpoint_path)
+            wandb_logger.log_model_artifact(weights_checkpoint_path)
 
     elapsed = round(time.time() - time_start)
     elapsed = str(datetime.timedelta(seconds=elapsed))

--- a/main.py
+++ b/main.py
@@ -178,6 +178,9 @@ def main():
                 args.save_dir,
             )
 
+            checkpoint_path = osp.join(args.save_dir, f"model.pth.tar-{epoch + 1}")
+            wandb_logger.log_model_artifact(checkpoint_path)
+
     elapsed = round(time.time() - time_start)
     elapsed = str(datetime.timedelta(seconds=elapsed))
     print(f"Elapsed {elapsed}")

--- a/main.py
+++ b/main.py
@@ -177,9 +177,12 @@ def main():
                 },
                 args.save_dir,
             )
-            # Log model checkpoint, weights only
-            checkpoint_path = osp.join(args.save_dir, f"model-{str(epoch+1)}.pth")
+            # Log model checkpoint
+            weights_only_path = osp.join(args.save_dir, f"model-{str(epoch+1)}.pth")
+            checkpoint_path = osp.join(args.save_dir, f"model-{str(epoch+1)}.pth.tar")
+            wandb_logger.log_model_artifact(weights_only_path)
             wandb_logger.log_model_artifact(checkpoint_path)
+
 
     elapsed = round(time.time() - time_start)
     elapsed = str(datetime.timedelta(seconds=elapsed))

--- a/main.py
+++ b/main.py
@@ -178,7 +178,7 @@ def main():
                 args.save_dir,
             )
 
-            checkpoint_path = osp.join(args.save_dir, f"model.pth.tar-{epoch + 1}")
+            checkpoint_path = osp.join(args.save_dir, f"model-{str(epoch+1)}.pth.tar")
             wandb_logger.log_model_artifact(checkpoint_path)
 
     elapsed = round(time.time() - time_start)

--- a/main.py
+++ b/main.py
@@ -179,9 +179,7 @@ def main():
             )
 
             checkpoint_path = osp.join(args.save_dir, f"model.pth.tar-{epoch + 1}")
-            weights_checkpoint_path = osp.join(args.save_dir, f"model_weights.pth.tar-{epoch + 1}")
             wandb_logger.log_model_artifact(checkpoint_path)
-            wandb_logger.log_model_artifact(weights_checkpoint_path)
 
     elapsed = round(time.time() - time_start)
     elapsed = str(datetime.timedelta(seconds=elapsed))

--- a/main.py
+++ b/main.py
@@ -177,8 +177,8 @@ def main():
                 },
                 args.save_dir,
             )
-
-            checkpoint_path = osp.join(args.save_dir, f"model-{str(epoch+1)}.pth.tar")
+            # Log model checkpoint, weights only
+            checkpoint_path = osp.join(args.save_dir, f"model-{str(epoch+1)}.pth")
             wandb_logger.log_model_artifact(checkpoint_path)
 
     elapsed = round(time.time() - time_start)

--- a/src/utils/torchtools.py
+++ b/src/utils/torchtools.py
@@ -24,7 +24,7 @@ def save_checkpoint(state, save_dir, is_best=False, remove_module_from_keys=Fals
         state["state_dict"] = new_state_dict
     # save
     epoch = state["epoch"]
-    fpath = osp.join(save_dir, "model.pth.tar-" + str(epoch))
+    fpath = osp.join(save_dir, f"model-{str(epoch)}.pth.tar")
     torch.save(state, fpath)
     print(f'Checkpoint saved to "{fpath}"')
     if is_best:

--- a/src/utils/torchtools.py
+++ b/src/utils/torchtools.py
@@ -25,15 +25,11 @@ def save_checkpoint(state, save_dir, is_best=False, remove_module_from_keys=Fals
     # save
     epoch = state["epoch"]
     fpath = osp.join(save_dir, "model.pth.tar-" + str(epoch))
-    wfpath = osp.join(save_dir, "model_weights.pth.tar-" + str(epoch))
     torch.save(state, fpath)
     print(f'Checkpoint saved to "{fpath}"')
-    # added this for better visualization on W&B
-    torch.save(state["state_dict"], wfpath)
-    print(f'Weights saved to "{wfpath}"')
     if is_best:
         shutil.copy(fpath, osp.join(osp.dirname(fpath), "best_model.pth.tar"))
-        shutil.copy(wfpath, osp.join(osp.dirname(wfpath), "best_model_weights.pth.tar"))
+
 
 def resume_from_checkpoint(ckpt_path, model, optimizer=None):
     print(f'Loading checkpoint from "{ckpt_path}"')

--- a/src/utils/torchtools.py
+++ b/src/utils/torchtools.py
@@ -25,11 +25,15 @@ def save_checkpoint(state, save_dir, is_best=False, remove_module_from_keys=Fals
     # save
     epoch = state["epoch"]
     fpath = osp.join(save_dir, "model.pth.tar-" + str(epoch))
+    wfpath = osp.join(save_dir, "model_weights.pth.tar-" + str(epoch))
     torch.save(state, fpath)
     print(f'Checkpoint saved to "{fpath}"')
+    # added this for better visualization on W&B
+    torch.save(state["state_dict"], wfpath)
+    print(f'Weights saved to "{wfpath}"')
     if is_best:
         shutil.copy(fpath, osp.join(osp.dirname(fpath), "best_model.pth.tar"))
-
+        shutil.copy(wfpath, osp.join(osp.dirname(wfpath), "best_model_weights.pth.tar"))
 
 def resume_from_checkpoint(ckpt_path, model, optimizer=None):
     print(f'Loading checkpoint from "{ckpt_path}"')

--- a/src/utils/torchtools.py
+++ b/src/utils/torchtools.py
@@ -25,10 +25,14 @@ def save_checkpoint(state, save_dir, is_best=False, remove_module_from_keys=Fals
     # save
     epoch = state["epoch"]
     fpath = osp.join(save_dir, f"model-{str(epoch)}.pth.tar")
+    wpath = osp.join(save_dir, f"model-{str(epoch)}.pth")
     torch.save(state, fpath)
+    torch.save(state["state_dict"], wpath)
     print(f'Checkpoint saved to "{fpath}"')
+    print(f"Weights saved to {wpath}")
     if is_best:
         shutil.copy(fpath, osp.join(osp.dirname(fpath), "best_model.pth.tar"))
+        shutil.copy(wpath, osp.join(osp.dirname(wpath), "best_model.pth"))
 
 
 def resume_from_checkpoint(ckpt_path, model, optimizer=None):

--- a/src/utils/wandb_logger.py
+++ b/src/utils/wandb_logger.py
@@ -82,7 +82,7 @@ class WandBLogger:
             "test/rank20": cmc[19] * 100,
         }
 
-    def log_model_artifact(self, checkpoint_path, name=None, type="model"):
+    def log_model_artifact(self, checkpoint_path, name=None):
         """Log a model checkpoint as a W&B artifact"""
         if self.enabled and not self.args.evaluate:
             if name is None:
@@ -93,7 +93,7 @@ class WandBLogger:
                 except:
                     name = f"{self.args.arch}_checkpoint"
 
-            artifact = wandb.Artifact(name=name, type=type)
+            artifact = wandb.Artifact(name=name, type="model")
             artifact.add_file(checkpoint_path)
             wandb.log_artifact(artifact)
             print(f"Logged model artifact '{name}' to W&B")

--- a/src/utils/wandb_logger.py
+++ b/src/utils/wandb_logger.py
@@ -20,7 +20,7 @@ class WandBLogger:
             student_id = os.getenv("STUDENT_ID")
             student_name = os.getenv("STUDENT_NAME")
 
-            aug_name = self._get_aug_name(self)
+            aug_name = self._get_aug_name()
             wandb.init(
                 project="VeRi",
                 name=f"{args.arch}_{aug_name}_{args.max_epoch}",

--- a/src/utils/wandb_logger.py
+++ b/src/utils/wandb_logger.py
@@ -89,7 +89,7 @@ class WandBLogger:
                 try:
                     epoch = checkpoint_path.split("-")[-1]
                     aug_name = self._get_aug_name()
-                    name = f"{self.args.arch}_{aug_name}_e{epoch}"
+                    name = f"{self.args.arch}_{aug_name}_{epoch}"
                 except:
                     name = f"{self.args.arch}_checkpoint"
 

--- a/src/utils/wandb_logger.py
+++ b/src/utils/wandb_logger.py
@@ -6,23 +6,29 @@ import time
 import os
 from dotenv import load_dotenv
 
+
 class WandBLogger:
     def __init__(self, args=None):
-        self.enabled = args is not None and hasattr(args, 'use_wandb') and args.use_wandb
+        self.enabled = (
+            args is not None and hasattr(args, "use_wandb") and args.use_wandb
+        )
         self.args = args
-        
+
         if self.enabled and not args.evaluate:
             load_dotenv()
             augmentations = []
             # by default, horizontal flips and translations are always applied
-            if args.random_erase: augmentations.append("erase")
-            if args.color_jitter: augmentations.append("jitter")
-            if args.color_aug: augmentations.append("color")
+            if args.random_erase:
+                augmentations.append("erase")
+            if args.color_jitter:
+                augmentations.append("jitter")
+            if args.color_aug:
+                augmentations.append("color")
             aug_name = "+".join(augmentations) if augmentations else "base"
-            
-            student_id = os.getenv('STUDENT_ID')
-            student_name = os.getenv('STUDENT_NAME')
-            
+
+            student_id = os.getenv("STUDENT_ID")
+            student_name = os.getenv("STUDENT_NAME")
+
             wandb.init(
                 project="VeRi",
                 name=f"{args.arch}_{aug_name}_{args.max_epoch}",
@@ -31,25 +37,29 @@ class WandBLogger:
             wandb.run.summary["student_id"] = student_id
             wandb.run.summary["student_name"] = student_name
             wandb.run.summary["uuid"] = str(uuid.uuid4())
-            wandb.run.summary["experiment_time"] = time.strftime("%Y-%m-%d %H:%M:%S", time.localtime())
-    
+            wandb.run.summary["experiment_time"] = time.strftime(
+                "%Y-%m-%d %H:%M:%S", time.localtime()
+            )
+
     def watch_model(self, model):
         """Watch model parameters and gradients"""
         if self.enabled and not self.args.evaluate:
             wandb.watch(model, log="all", log_freq=100)
-    
+
     def log_train_metrics(self, metrics, epoch, batch_idx, trainloader_len):
         """Log training metrics with step based on epoch and batch index"""
         if self.enabled:
             step = epoch * trainloader_len + batch_idx
             wandb.log(metrics, step=step)
-    
+
     def log_test_metrics(self, metrics):
         """Log testing/evaluation metrics"""
         if self.enabled and not self.args.evaluate:  # Only log during training runs
             wandb.log(metrics)
-    
-    def format_train_metrics(self, xent_loss, htri_loss, accuracy, learning_rate, lambda_xent, lambda_htri):
+
+    def format_train_metrics(
+        self, xent_loss, htri_loss, accuracy, learning_rate, lambda_xent, lambda_htri
+    ):
         """Format training metrics for logging"""
         return {
             "train/xent_loss": xent_loss,
@@ -58,7 +68,7 @@ class WandBLogger:
             "train/accuracy": accuracy,
             "train/learning_rate": learning_rate,
         }
-    
+
     def format_test_metrics(self, mAP, cmc):
         """Format test metrics for logging"""
         return {
@@ -68,7 +78,27 @@ class WandBLogger:
             "test/rank10": cmc[9] * 100,
             "test/rank20": cmc[19] * 100,
         }
-    
+
+    def log_model_artifact(self, checkpoint_path, name=None, type="model"):
+        """Log a model checkpoint as a W&B artifact"""
+        if self.enabled and not self.args.evaluate:
+            if name is None:
+                try:
+                    epoch = checkpoint_path.split('-')[-1]
+                    augmentations = []
+                    if self.args.random_erase: augmentations.append("erase")
+                    if self.args.color_jitter: augmentations.append("jitter")
+                    if self.args.color_aug: augmentations.append("color")
+                    aug_name = "+".join(augmentations) if augmentations else "base"
+                    name = f"{self.args.arch}_{aug_name}_e{epoch}"
+                except:
+                    name = f"{self.args.arch}_checkpoint"
+                
+            artifact = wandb.Artifact(name=name, type=type)
+            artifact.add_file(checkpoint_path)
+            wandb.log_artifact(artifact)
+            print(f"Logged model artifact '{name}' to W&B")
+
     def finish(self):
         """End the wandb run"""
         if self.enabled:

--- a/src/utils/wandb_logger.py
+++ b/src/utils/wandb_logger.py
@@ -20,7 +20,7 @@ class WandBLogger:
             student_id = os.getenv("STUDENT_ID")
             student_name = os.getenv("STUDENT_NAME")
 
-            aug_name = _get_aug_name(self)
+            aug_name = self._get_aug_name(self)
             wandb.init(
                 project="VeRi",
                 name=f"{args.arch}_{aug_name}_{args.max_epoch}",


### PR DESCRIPTION
Added both weights-only and full model file. Might have to tweak the naming convention later based on the experiments.

### Makefile updates:
* Added new training targets for `resnet34`, `resnet50`, and `vgg16` to the `Makefile`. These targets include specific configurations for training each model.

### Logging improvements:
* Updated `main.py` to log model and weights checkpoints using the `WandBLogger` class.
* Modified `src/utils/torchtools.py` to save model weights separately for better visualization on W&B (Weights & Biases).

### Refactoring:
* Refactored the `WandBLogger` class in `src/utils/wandb_logger.py` to improve readability and functionality:
  * Moved augmentation name generation to a separate method `_get_aug_name`. [[1]](diffhunk://#diff-06a3ad934de7c90cef1178a597d222f71b08cce03babc2cfc7b32eeee1137658R9-R23) [[2]](diffhunk://#diff-06a3ad934de7c90cef1178a597d222f71b08cce03babc2cfc7b32eeee1137658L34-R45)
  * Added a method `log_model_artifact` to log model checkpoints as W&B artifacts.
  * Reformatted method signatures for better readability.